### PR TITLE
File variable naming

### DIFF
--- a/ADT/EXT_Server/oag.py
+++ b/ADT/EXT_Server/oag.py
@@ -1,6 +1,6 @@
 ## OAG Import Module
 
-# OAG Flight Status XML Import 
+# OAG Flight Status XML Import
 # Version 5
 # 2015-10-30
 
@@ -24,165 +24,165 @@ module_logger = logging.getLogger('oag')
 # Build sql statements using named parameters
 
 _sql={
-	'oag_flight' : """	
-		insert into oag_flight 
-		( 
-			flight_transid, 
-			flight_sent_utc_datetime, 
-			flight_utcloc, 
+	'oag_flight' : """
+		insert into oag_flight
+		(
+			flight_transid,
+			flight_sent_utc_datetime,
+			flight_utcloc,
 			flight_sent_datetime,
 			flight_oag_type
 		)
 		values
-		( 
-			%(flight_transid)s, 
-			%(flight_sent_utc_datetime)s, 
-			%(flight_utcloc)s, 
+		(
+			%(flight_transid)s,
+			%(flight_sent_utc_datetime)s,
+			%(flight_utcloc)s,
 			%(flight_sent_datetime)s,
 			%(flight_oag_type)s
-		) 
+		)
 		returning flight_id
 	""",
-	
+
 	'oag_carrier' : """
-		insert into oag_carrier 
-		( 
-			carrier_flight_id, 
-			carrier_code, 
+		insert into oag_carrier
+		(
+			carrier_flight_id,
+			carrier_code,
 			carrier_flightnumber,
 			carrier_codeshare_type
-		)  
-		values 
-		( 
-			%(carrier_flight_id)s, 
-			%(carrier_code)s, 
+		)
+		values
+		(
+			%(carrier_flight_id)s,
+			%(carrier_code)s,
 			%(carrier_flightnumber)s,
 			%(carrier_codeshare_type)s
 		)
 	""",
 
 	'oag_leg' : """
-		insert into oag_leg 
-		( 
-			leg_arr_apt, 
-			leg_aircraft_ch, 
-			leg_dep_checkin_act, 
-			leg_dep_offblock_ch, 
-			leg_arr_onblock_est_datetime, 
-			leg_arr_delay_stat, 
-			leg_aircraft_reg_ch, 
-			leg_dep_trm_act, 
-			leg_dep_checkin_ch, 
-			leg_dep_delay_stat, 
-			leg_service_type, 
-			leg_arr_gate_ch, 
-			leg_dep_trm_ch, 
-			leg_arr_delay_det, 
-			leg_dep_airborne_ch, 
-			leg_arr_trm_act, 
-			leg_arr_trm_ch, 
-			leg_arr_down_ch, 
-			leg_flight_id, 
-			leg_arr_onblock_act_datetime, 
-			leg_dep_offblock_est_datetime, 
-			leg_dep_datetime_act_datetime, 
-			leg_arr_datetime_act_datetime, 
-			leg_dep_delay_catid, 
-			leg_arr_gate_act, 
+		insert into oag_leg
+		(
+			leg_arr_apt,
+			leg_aircraft_ch,
+			leg_dep_checkin_act,
+			leg_dep_offblock_ch,
+			leg_arr_onblock_est_datetime,
+			leg_arr_delay_stat,
+			leg_aircraft_reg_ch,
+			leg_dep_trm_act,
+			leg_dep_checkin_ch,
+			leg_dep_delay_stat,
+			leg_service_type,
+			leg_arr_gate_ch,
+			leg_dep_trm_ch,
+			leg_arr_delay_det,
+			leg_dep_airborne_ch,
+			leg_arr_trm_act,
+			leg_arr_trm_ch,
+			leg_arr_down_ch,
+			leg_flight_id,
+			leg_arr_onblock_act_datetime,
+			leg_dep_offblock_est_datetime,
+			leg_dep_datetime_act_datetime,
+			leg_arr_datetime_act_datetime,
+			leg_dep_delay_catid,
+			leg_arr_gate_act,
 			leg_aircraft_schd,
-			leg_dep_datetime_schd_datetime, 
-			leg_arr_city, 
-			leg_dep_datetime_est_datetime, 
-			leg_dep_offblock_act_datetime, 
-			leg_dep_delay_det, 
-			leg_dep_datetime_ch, 
-			leg_arr_claim_act, 
-			leg_arr_divert_city, 
-			leg_arr_delay_catid, 
-			leg_arr_datetime_ch, 
-			leg_arr_datetime_schd_datetime, 
-			leg_dep_trm_schd, 
-			leg_arr_datetime_est_datetime, 
-			leg_dep_gate_act, 
-			leg_arr_down_est_datetime, 
-			leg_dep_airborne_act_datetime, 
-			leg_arr_onblock_ch, 
-			leg_aircraft_act, 
-			leg_dep_city, 
-			leg_arr_down_act_datetime, 
-			leg_aircraft_reg_act, 
-			leg_arr_trm_schd, 
-			leg_dep_apt, 
-			leg_arr_divert_apt, 
-			leg_dep_airborne_est_datetime, 
-			leg_dep_gate_ch, 
-			leg_arr_claim_ch 
-		)  
-		values 
-		( 
-			%(leg_arr_apt)s, 
-			%(leg_aircraft_ch)s, 
-			%(leg_dep_checkin_act)s, 
-			%(leg_dep_offblock_ch)s, 
-			%(leg_arr_onblock_est_datetime)s, 
-			%(leg_arr_delay_stat)s, 
-			%(leg_aircraft_reg_ch)s, 
-			%(leg_dep_trm_act)s, 
-			%(leg_dep_checkin_ch)s, 
-			%(leg_dep_delay_stat)s, 
-			%(leg_service_type)s, 
-			%(leg_arr_gate_ch)s, 
-			%(leg_dep_trm_ch)s, 
-			%(leg_arr_delay_det)s, 
-			%(leg_dep_airborne_ch)s, 
-			%(leg_arr_trm_act)s, 
-			%(leg_arr_trm_ch)s, 
-			%(leg_arr_down_ch)s, 
-			%(leg_flight_id)s, 
-			%(leg_arr_onblock_act_datetime)s, 
-			%(leg_dep_offblock_est_datetime)s, 
-			%(leg_dep_datetime_act_datetime)s, 
-			%(leg_arr_datetime_act_datetime)s, 
-			%(leg_dep_delay_catid)s, 
-			%(leg_arr_gate_act)s, 
-			%(leg_aircraft_schd)s, 
-			%(leg_dep_datetime_schd_datetime)s, 
-			%(leg_arr_city)s, 
-			%(leg_dep_datetime_est_datetime)s, 
-			%(leg_dep_offblock_act_datetime)s, 
-			%(leg_dep_delay_det)s, 
-			%(leg_dep_datetime_ch)s, 
-			%(leg_arr_claim_act)s, 
-			%(leg_arr_divert_city)s, 
-			%(leg_arr_delay_catid)s, 
-			%(leg_arr_datetime_ch)s, 
+			leg_dep_datetime_schd_datetime,
+			leg_arr_city,
+			leg_dep_datetime_est_datetime,
+			leg_dep_offblock_act_datetime,
+			leg_dep_delay_det,
+			leg_dep_datetime_ch,
+			leg_arr_claim_act,
+			leg_arr_divert_city,
+			leg_arr_delay_catid,
+			leg_arr_datetime_ch,
+			leg_arr_datetime_schd_datetime,
+			leg_dep_trm_schd,
+			leg_arr_datetime_est_datetime,
+			leg_dep_gate_act,
+			leg_arr_down_est_datetime,
+			leg_dep_airborne_act_datetime,
+			leg_arr_onblock_ch,
+			leg_aircraft_act,
+			leg_dep_city,
+			leg_arr_down_act_datetime,
+			leg_aircraft_reg_act,
+			leg_arr_trm_schd,
+			leg_dep_apt,
+			leg_arr_divert_apt,
+			leg_dep_airborne_est_datetime,
+			leg_dep_gate_ch,
+			leg_arr_claim_ch
+		)
+		values
+		(
+			%(leg_arr_apt)s,
+			%(leg_aircraft_ch)s,
+			%(leg_dep_checkin_act)s,
+			%(leg_dep_offblock_ch)s,
+			%(leg_arr_onblock_est_datetime)s,
+			%(leg_arr_delay_stat)s,
+			%(leg_aircraft_reg_ch)s,
+			%(leg_dep_trm_act)s,
+			%(leg_dep_checkin_ch)s,
+			%(leg_dep_delay_stat)s,
+			%(leg_service_type)s,
+			%(leg_arr_gate_ch)s,
+			%(leg_dep_trm_ch)s,
+			%(leg_arr_delay_det)s,
+			%(leg_dep_airborne_ch)s,
+			%(leg_arr_trm_act)s,
+			%(leg_arr_trm_ch)s,
+			%(leg_arr_down_ch)s,
+			%(leg_flight_id)s,
+			%(leg_arr_onblock_act_datetime)s,
+			%(leg_dep_offblock_est_datetime)s,
+			%(leg_dep_datetime_act_datetime)s,
+			%(leg_arr_datetime_act_datetime)s,
+			%(leg_dep_delay_catid)s,
+			%(leg_arr_gate_act)s,
+			%(leg_aircraft_schd)s,
+			%(leg_dep_datetime_schd_datetime)s,
+			%(leg_arr_city)s,
+			%(leg_dep_datetime_est_datetime)s,
+			%(leg_dep_offblock_act_datetime)s,
+			%(leg_dep_delay_det)s,
+			%(leg_dep_datetime_ch)s,
+			%(leg_arr_claim_act)s,
+			%(leg_arr_divert_city)s,
+			%(leg_arr_delay_catid)s,
+			%(leg_arr_datetime_ch)s,
 			%(leg_arr_datetime_schd_datetime)s,
-			%(leg_dep_trm_schd)s, 
-			%(leg_arr_datetime_est_datetime)s, 
-			%(leg_dep_gate_act)s, 
-			%(leg_arr_down_est_datetime)s, 
-			%(leg_dep_airborne_act_datetime)s, 
-			%(leg_arr_onblock_ch)s, 
-			%(leg_aircraft_act)s, 
-			%(leg_dep_city)s, 
-			%(leg_arr_down_act_datetime)s, 
-			%(leg_aircraft_reg_act)s, 
-			%(leg_arr_trm_schd)s, 
-			%(leg_dep_apt)s, 
-			%(leg_arr_divert_apt)s, 
-			%(leg_dep_airborne_est_datetime)s, 
-			%(leg_dep_gate_ch)s, 
-			%(leg_arr_claim_ch)s 
+			%(leg_dep_trm_schd)s,
+			%(leg_arr_datetime_est_datetime)s,
+			%(leg_dep_gate_act)s,
+			%(leg_arr_down_est_datetime)s,
+			%(leg_dep_airborne_act_datetime)s,
+			%(leg_arr_onblock_ch)s,
+			%(leg_aircraft_act)s,
+			%(leg_dep_city)s,
+			%(leg_arr_down_act_datetime)s,
+			%(leg_aircraft_reg_act)s,
+			%(leg_arr_trm_schd)s,
+			%(leg_dep_apt)s,
+			%(leg_arr_divert_apt)s,
+			%(leg_dep_airborne_est_datetime)s,
+			%(leg_dep_gate_ch)s,
+			%(leg_arr_claim_ch)s
 		)
 	""",
-	
+
 	'history' : """
-		update history 
-		set source_date=%(lastupdated)s 
+		update history
+		set source_date=%(lastupdated)s
 		where source_type='O'
 	""",
-	
-	'schd' : """	
+
+	'schd' : """
 		insert into schd
 		(
 			source,
@@ -237,11 +237,11 @@ _sql={
 			carrier_id,
 			leg_id,
 			carrier_iata as airline_iata,
-			carrier_icao as airline_icao,		 
+			carrier_icao as airline_icao,
 			carrier_flightnumber as flightnumber,
 			carrier_codeshare_type as codeshare,
 			operating_flightnumber as operating_flightnumber,
-			(case 
+			(case
 				when arr_dep = 'A' then arr_datetime::date
 				when arr_dep = 'D' then dep_datetime::date
 			end) as flight_date,
@@ -256,20 +256,20 @@ _sql={
 			leg_dep_apt as origin_iata,
 			leg_dep_apt_icao as origin_icao,
 			leg_arr_apt as destination_iata,
-			leg_arr_apt_icao as destination_icao,		
-			(case 
+			leg_arr_apt_icao as destination_icao,
+			(case
 				when arr_dep = 'A' then leg_arr_apt
 				when arr_dep = 'D' then leg_dep_apt
 			end) as airport_iata,
-			(case 
+			(case
 				when arr_dep = 'A' then leg_arr_apt_icao
 				when arr_dep = 'D' then leg_dep_apt_icao
 			end) as airport_icao,
-			(case 
+			(case
 				when arr_dep = 'A' then leg_dep_apt
 				when arr_dep = 'D' then leg_arr_apt
 			end) as last_next_iata,
-			(case 
+			(case
 				when arr_dep = 'A' then leg_dep_apt_icao
 				when arr_dep = 'D' then leg_arr_apt_icao
 			end) as last_next_icao,
@@ -289,10 +289,10 @@ _sql={
 			arr_dep as arr_dep,
 			flight_oag_type as oag_type,
 			flight_transid as flight_transid,
-			( leg_dep_apt || leg_arr_apt || to_char((case 
+			( leg_dep_apt || leg_arr_apt || to_char((case
 				when arr_dep = 'A' then arr_datetime::date
 				when arr_dep = 'D' then dep_datetime::date
-			end),'YYYYMMDD') || btrim(coalesce(carrier_iata,carrier_icao)) || btrim(carrier_flightnumber) || arr_dep) as voyageid		
+			end),'YYYYMMDD') || btrim(coalesce(carrier_iata,carrier_icao)) || btrim(carrier_flightnumber) || arr_dep) as voyageid
 		from (
 				select
 					F.flight_id,
@@ -323,67 +323,67 @@ _sql={
 					OF2.airport_timezone_name,
 					L.leg_dep_delay_catid,
 					L.leg_dep_delay_det,
-					L.leg_dep_delay_stat,	
+					L.leg_dep_delay_stat,
 					L.leg_arr_delay_catid,
 					L.leg_arr_delay_det,
-					L.leg_arr_delay_stat,	
+					L.leg_arr_delay_stat,
 					-- calculated fields
-					(case 
-						when length(C.carrier_flightnumber) < 4 
-						then '0' || C.carrier_flightnumber 
-						else C.carrier_flightnumber 
+					(case
+						when length(C.carrier_flightnumber) < 4
+						then '0' || C.carrier_flightnumber
+						else C.carrier_flightnumber
 					end) as oag_flightnumber,
-					(case 
-						when F.flight_utcloc = 'UTC' 
-						then L.leg_dep_datetime_schd_datetime 
-						else L.leg_dep_datetime_schd_datetime at time zone OF1.airport_timezone_name 
+					(case
+						when F.flight_utcloc = 'UTC'
+						then L.leg_dep_datetime_schd_datetime
+						else L.leg_dep_datetime_schd_datetime at time zone OF1.airport_timezone_name
 					end) as dep_datetime,
-					(case 
-						when F.flight_utcloc = 'UTC' 
+					(case
+						when F.flight_utcloc = 'UTC'
 						then L.leg_arr_datetime_schd_datetime
-						else L.leg_arr_datetime_schd_datetime at time zone OF2.airport_timezone_name 
+						else L.leg_arr_datetime_schd_datetime at time zone OF2.airport_timezone_name
 					end) as arr_datetime,
-					(case 
-						when F.flight_utcloc = 'UTC' 
+					(case
+						when F.flight_utcloc = 'UTC'
 						then L.leg_dep_datetime_est_datetime
-						else L.leg_dep_datetime_est_datetime at time zone OF1.airport_timezone_name 
+						else L.leg_dep_datetime_est_datetime at time zone OF1.airport_timezone_name
 					end) as dep_est_datetime,
-					(case 
-						when F.flight_utcloc = 'UTC' 
+					(case
+						when F.flight_utcloc = 'UTC'
 						then L.leg_dep_datetime_act_datetime
-						else L.leg_dep_datetime_act_datetime at time zone OF1.airport_timezone_name 
+						else L.leg_dep_datetime_act_datetime at time zone OF1.airport_timezone_name
 					end) as dep_act_datetime,
-					(case 
-						when F.flight_utcloc = 'UTC' 
+					(case
+						when F.flight_utcloc = 'UTC'
 						then L.leg_dep_offblock_act_datetime
-						else L.leg_dep_offblock_act_datetime at time zone OF1.airport_timezone_name 
+						else L.leg_dep_offblock_act_datetime at time zone OF1.airport_timezone_name
 					end) as offblock_datetime,
-					(case 
-						when F.flight_utcloc = 'UTC' 
+					(case
+						when F.flight_utcloc = 'UTC'
 						then L.leg_dep_airborne_act_datetime
-						else L.leg_dep_airborne_act_datetime at time zone OF1.airport_timezone_name 
+						else L.leg_dep_airborne_act_datetime at time zone OF1.airport_timezone_name
 					end) as airborne_datetime,
-					(case 
-						when F.flight_utcloc = 'UTC' 
+					(case
+						when F.flight_utcloc = 'UTC'
 						then L.leg_arr_down_act_datetime
-						else L.leg_arr_down_act_datetime at time zone OF2.airport_timezone_name 
+						else L.leg_arr_down_act_datetime at time zone OF2.airport_timezone_name
 					end) as down_datetime,
-					(case 
-						when F.flight_utcloc = 'UTC' 
+					(case
+						when F.flight_utcloc = 'UTC'
 						then L.leg_arr_onblock_act_datetime
-						else L.leg_arr_onblock_act_datetime at time zone OF2.airport_timezone_name 
+						else L.leg_arr_onblock_act_datetime at time zone OF2.airport_timezone_name
 					end) as on_datetime,
-					(case 
-						when F.flight_utcloc = 'UTC' 
+					(case
+						when F.flight_utcloc = 'UTC'
 						then L.leg_arr_datetime_est_datetime
-						else L.leg_arr_datetime_est_datetime at time zone OF2.airport_timezone_name 
+						else L.leg_arr_datetime_est_datetime at time zone OF2.airport_timezone_name
 					end) as arr_est_datetime,
-					(case 
-						when F.flight_utcloc = 'UTC' 
+					(case
+						when F.flight_utcloc = 'UTC'
 						then L.leg_arr_datetime_act_datetime
-						else L.leg_arr_datetime_act_datetime at time zone OF2.airport_timezone_name 
+						else L.leg_arr_datetime_act_datetime at time zone OF2.airport_timezone_name
 					end) as arr_act_datetime,
-					(case 
+					(case
 						when IA.airport_iata = leg_dep_apt then 'D'
 						when IA.airport_iata = leg_arr_apt then 'A'
 					end) as arr_dep,
@@ -394,9 +394,9 @@ _sql={
 					(case
 						when leg_aircraft_ch = 'Y' then AA1.aircraft_icao
 						else AA2.aircraft_icao
-					end) as aircraft_icao,				
-					T.servicetype_pax,				
-					'O' as source				
+					end) as aircraft_icao,
+					T.servicetype_pax,
+					'O' as source
 				from oag_flight F
 				join oag_leg L
 					on L.leg_flight_id = F.flight_id
@@ -404,13 +404,13 @@ _sql={
 					on C.carrier_flight_id = F.flight_id
 					and carrier_codeshare_type is not null
 				join of_airlines OFA
-					on OFA.airline_iata = C.carrier_code 
-					and airline_active='Y'				
+					on OFA.airline_iata = C.carrier_code
+					and airline_active='Y'
 				join of_airports OF1
 					on OF1.airport_iata = leg_dep_apt
 				join of_airports OF2
 					on OF2.airport_iata = leg_arr_apt
-				join servicetypes T 
+				join servicetypes T
 					on L.leg_service_type = servicetype_code
 				join interested_airports IA
 					on IA.airport_iata = leg_dep_apt
@@ -419,21 +419,21 @@ _sql={
 					on CS.carrier_flight_id = F.flight_id
 					and ( CS.carrier_codeshare_type is null or CS.carrier_codeshare_type = 0 )
 					and C.carrier_codeshare_type = 1
-				left join bb_aircraft AA1 
+				left join bb_aircraft AA1
 					on leg_aircraft_act = AA1.aircraft_iata
-				left join bb_aircraft AA2 
+				left join bb_aircraft AA2
 					on leg_aircraft_schd = AA2.aircraft_iata
 				where
 					flight_sent_utc_datetime > (select coalesce(max(lastupdated),'2015-01-01'::date) as d from schd where source='O')
 					-- flight_sent_utc_datetime::date >= '2015-09-14'::date
 		) Z
-		order by 
+		order by
 			dep_datetime,
 			arr_datetime,
 			carrier_code,
-			carrier_flightnumber,		
+			carrier_flightnumber,
 			flight_sent_utc_datetime,
-			flight_id	
+			flight_id
 	""",
 
 	'file_check' : """
@@ -442,7 +442,7 @@ _sql={
 		from oag_files
 		where filename = %(filename)s
 	""",
-	
+
 	'file_update' : """
 		insert into oag_files
 		(
@@ -469,42 +469,42 @@ def _process_file(dbh,xml):
 
 	if xml.NodeType() == libxml2.XML_READER_TYPE_ELEMENT and xml.Name() == 'FIMSSR':
 		module_logger.debug('FIMSSR %s %s',xml.NodeType(),xml.Name())
-		
+
 		# process FIMSSR wrapper
 		sent=xml.GetAttribute('Sent')
 		sentutc=xml.GetAttribute('UTCSent')
 		locutc=xml.GetAttribute('UTCLOCInd')
-				
+
 		# Flight Loop
 		while xml.Read():
 			module_logger.debug('X %s %s',xml.NodeType(),xml.Name())
-				
+
 			if xml.NodeType() == libxml2.XML_READER_TYPE_ELEMENT and xml.Name() == 'Flight':
 				module_logger.debug('Flight %s %s',xml.NodeType(),xml.Name())
-				
-				carrier={ 
-					'carrier_code' : None, 
-					'carrier_flightnumber' : None, 
+
+				carrier={
+					'carrier_code' : None,
+					'carrier_flightnumber' : None,
 					'carrier_flight_id' : None,
 					'carrier_codeshare_type' : 0
 				}
 
 				# transid is OAG's unique ID - but all codeshares have the same transid
 				transid=xml.GetAttribute('TransId')
-				
+
 				oagtype='U'
-				
+
 				if transid[0] == 'S':
 					oagtype='S'
-								
+
 				carrier['carrier_code']=xml.GetAttribute('Carrier')
 				carrier['carrier_flightnumber']=xml.GetAttribute('FltNo')
-				
+
 				carrier_uniq=carrier['carrier_code']+'#'+carrier['carrier_flightnumber']
 
 				module_logger.debug("F %s %s %s", transid, carrier, oagtype)
 
-				flight={ 
+				flight={
 					'flight_id' : None,
 					'flight_transid' : transid,
 					'flight_sent_datetime' : sent,
@@ -514,25 +514,25 @@ def _process_file(dbh,xml):
 					'carriers' : {},
 					'legs' : [],
 				}
-				
+
 				flight['carriers'][carrier_uniq]=carrier
-				
+
 				# Leg Loop
 				while xml.Read():
 					module_logger.debug('X %s %s',xml.NodeType(),xml.Name())
 
 					if xml.NodeType() == libxml2.XML_READER_TYPE_ELEMENT and xml.Name() == 'Leg':
 						module_logger.debug('Leg %s %s',xml.NodeType(),xml.Name())
-						
+
 						_process_leg(xml,flight)
-						
+
 					if xml.NodeType() == libxml2.XML_READER_TYPE_END_ELEMENT and xml.Name() == 'Flight':
-						break					
+						break
 				# end Leg Loop
-				
+
 				if transid in flights:
 					# if transid exists we have seen this flight before
-					
+
 					# add code share only - discard duplicated data
 					for c in flight['carriers']:
 						if c in flights[transid]['carriers']:
@@ -544,25 +544,25 @@ def _process_file(dbh,xml):
 				else:
 					# new flight
 					flights[transid]=flight
-					
+
 				module_logger.debug(flights[transid])
 
 		#end Flight Loop
 
 	# end if FIMSSR
-	
+
 	# insert flights into DB
-	
+
 	for transid in flights:
-		
+
 		try:
 			module_logger.debug("Insert %s", transid)
-				
+
 			csr=dbh.cursor()
-			
+
 			# use named bind parameters
 			csr.execute( _sql['oag_flight'],
-				{ 
+				{
 					'flight_transid' : flights[transid]['flight_transid'],
 					'flight_sent_datetime' : flights[transid]['flight_sent_datetime'],
 					'flight_sent_utc_datetime' : flights[transid]['flight_sent_utc_datetime'],
@@ -570,66 +570,66 @@ def _process_file(dbh,xml):
 					'flight_oag_type' : flights[transid]['flight_oag_type'],
 				}
 			)
-			
+
 			module_logger.debug("Q %s", csr.query)
 			module_logger.debug("R %s", csr.statusmessage)
-			
+
 			# get flight_id via the "returning" clause
 			flight_id = csr.fetchone()[0]
-			
+
 			module_logger.debug("Flight ID %s", flight_id)
 
 			if flight_id:
 				for c in flights[transid]['carriers']:
 					carrier=flights[transid]['carriers'][c]
-					
+
 					module_logger.debug("Carrier %s %s %s", c, carrier['carrier_code'], carrier['carrier_flightnumber'])
-					
+
 					carrier['carrier_flight_id']=flight_id
-					
+
 					# we can use a dictionary as named bind parameter
 					csr.execute( _sql['oag_carrier'], carrier )
-					
+
 					module_logger.debug("Q %s", csr.query)
 					module_logger.debug("R %s", csr.statusmessage)
-					
+
 				for leg in flights[transid]['legs']:
 					module_logger.debug("Leg")
-					
+
 					leg['leg_flight_id']=flight_id
-					
+
 					# we can use a dictionary as named bind parameter
 					csr.execute( _sql['oag_leg'], leg )
-					
+
 					module_logger.debug("Q %s", csr.query)
 					module_logger.debug("R %s", csr.statusmessage)
-				
+
 				csr.execute( _sql['history'],  { 'lastupdated' : sentutc } )
 
 				module_logger.debug("Q %s", csr.query)
 				module_logger.debug("R %s", csr.statusmessage)
 
-				
+
 			csr.close()
 
 			module_logger.debug("Commit")
 
 			dbh.commit()
-			
-		except:	
+
+		except:
 			module_logger.exception("Rollback")
 
 			csr.close()
-			
+
 			dbh.rollback()
-			
+
 			status=-2
 			message="Database error"
-			
+
 	#end for
 
-	return status, message	
-	
+	return status, message
+
 # end def _process_file
 
 
@@ -664,7 +664,7 @@ def _process_leg(xml,flight):
 		'leg_arr_trm_schd' : None,
 		'leg_arr_apt' : None,
 		'leg_arr_city' : None,
-		
+
 		'leg_dep_airborne_act_datetime' : None,
 		'leg_dep_airborne_ch' : None,
 		'leg_dep_airborne_est_datetime' : None,
@@ -687,16 +687,16 @@ def _process_leg(xml,flight):
 		'leg_dep_trm_schd' : None,
 		'leg_dep_apt' : None,
 		'leg_dep_city' : None,
-		
+
 		'leg_aircraft_reg_act' : None,
 		'leg_aircraft_reg_ch' : None,
 		'leg_aircraft_act' : None,
 		'leg_aircraft_ch' : None,
-		'leg_aircraft_schd' : None,				
+		'leg_aircraft_schd' : None,
 	}
-		
+
 	leg['leg_service_type']=xml.GetAttribute('SvcTypeCd')
-	
+
 	while xml.Read():
 		module_logger.debug('X %s %s',xml.NodeType(),xml.Name())
 
@@ -711,14 +711,14 @@ def _process_leg(xml,flight):
 
 		if xml.NodeType() == libxml2.XML_READER_TYPE_END_ELEMENT and xml.Name() == 'Leg':
 			break
-			
+
 	flight['legs'].append(leg)
 
 # end def _process_leg
 
 def _process_leg_equip(xml,leg):
 	module_logger.debug('Equip %s %s',xml.NodeType(),xml.Name())
-		
+
 	leg['leg_aircraft_schd']=xml.GetAttribute('Schd')
 	leg['leg_aircraft_ch']=xml.GetAttribute('Ch')
 	leg['leg_aircraft_act']=xml.GetAttribute('Act')
@@ -733,7 +733,7 @@ def _process_leg_equip(xml,leg):
 				leg['leg_aircraft_reg_ch']=xml.GetAttribute('Ch')
 				leg['leg_aircraft_reg_act']=xml.GetAttribute('Act')
 				break
-			
+
 			if xml.NodeType() == libxml2.XML_READER_TYPE_END_ELEMENT and xml.Name() == 'Equip':
 				break
 
@@ -743,9 +743,9 @@ def _process_leg_codeshare(xml,flight):
 	module_logger.debug('CodeShare %s %s',xml.NodeType(),xml.Name())
 
 	carrier_codeshare_type=xml.GetAttribute('Type')
-	
+
 	module_logger.debug("CS Type %s", carrier_codeshare_type)
-	
+
 	if carrier_codeshare_type == '1':
 		carrier_code=xml.GetAttribute('Desig')
 		carrier_flightnumber=xml.GetAttribute('FltNo')
@@ -753,23 +753,23 @@ def _process_leg_codeshare(xml,flight):
 		carrier_uniq=carrier_code+'#'+carrier_flightnumber
 
 		module_logger.debug("CS U %s",carrier_uniq)
-			
+
 		# flag all carriers that don't match the metal carrier
 		# however only 1 carrier should be in the flight so we could flag them all
 		for c in flight['carriers']:
 			module_logger.debug("CS C %s", c)
 			if c != carrier_uniq:
 				flight['carriers'][c]['carrier_codeshare_type']=1 # code share
-		
+
 		if not carrier_uniq in flight['carriers']:
-			carrier={ 
-				'carrier_code' : carrier_code, 
-				'carrier_flightnumber' : carrier_flightnumber, 
+			carrier={
+				'carrier_code' : carrier_code,
+				'carrier_flightnumber' : carrier_flightnumber,
 				'carrier_flight_id' : None,
 				'carrier_codeshare_type' : None # metal for info only
 			}
 			flight['carriers'][carrier_uniq]=carrier
-		
+
 # end def _process_leg_codeshare
 
 def _process_leg_dep(xml, leg):
@@ -828,7 +828,7 @@ def _process_leg_dep(xml, leg):
 			leg['leg_dep_delay_catid']=xml.GetAttribute('CatId')
 			leg['leg_dep_delay_det']=xml.GetAttribute('Det')
 			leg['leg_dep_delay_stat']=xml.GetAttribute('Stat')
-			
+
 		if xml.NodeType() == libxml2.XML_READER_TYPE_END_ELEMENT and xml.Name() == 'Dep':
 			break
 
@@ -864,7 +864,7 @@ def _process_leg_arr(xml, leg):
 
 		if xml.NodeType() == libxml2.XML_READER_TYPE_ELEMENT and xml.Name() == 'DateTime':
 			module_logger.debug('DateTime %s %s',xml.NodeType(),xml.Name())
-			
+
 			leg['leg_arr_datetime_ch']=xml.GetAttribute('Ch')
 			leg['leg_arr_datetime_act_datetime']=xml.GetAttribute('Act')
 			leg['leg_arr_datetime_schd_datetime']=xml.GetAttribute('Schd')
@@ -879,7 +879,7 @@ def _process_leg_arr(xml, leg):
 
 		if xml.NodeType() == libxml2.XML_READER_TYPE_ELEMENT and xml.Name() == 'Down':
 			module_logger.debug('Down %s %s',xml.NodeType(),xml.Name())
-			
+
 			leg['leg_arr_down_ch']=xml.GetAttribute('Ch')
 			leg['leg_arr_down_act_datetime']=xml.GetAttribute('Act')
 			leg['leg_arr_down_est_datetime']=xml.GetAttribute('Est')
@@ -905,10 +905,10 @@ def _process_leg_arr(xml, leg):
 
 def _schdupdate(dbh):
 	module_logger.info("schd update")
-	
+
 	status=1
 	message='OK'
-	
+
 	try:
 		module_logger.debug("SCHD update")
 
@@ -925,7 +925,7 @@ def _schdupdate(dbh):
 
 		dbh.commit()
 
-	except:	
+	except:
 		module_logger.exception("Rollback")
 
 		csr.close()

--- a/ADT/EXT_Server/oag_house_keeping.sh
+++ b/ADT/EXT_Server/oag_house_keeping.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+#Maintaining 90 days of ssm data only due to capacity
+find /appdata/ADT/archive/oag/ -type f -mtime +90 -delete

--- a/ADT/WEB_Server/ftp_acl_web02.py
+++ b/ADT/WEB_Server/ftp_acl_web02.py
@@ -97,28 +97,28 @@ def main():
 
 	# process download folder for downloaded files and move to archive folder
 	logger.debug("Scanning download folder %s", download_dir)
-	for f in os.listdir(download_dir):
-		logger.debug("File %s", f)
+	for file_done in os.listdir(download_dir):
+		logger.debug("File %s", file_done)
 
-		match = re.search('^((.*?)homeofficeroll(\d+)_(\d{4}\d{2}\d{2})\.csv)\.done$', f, re.I)
+		match = re.search('^((.*?)homeofficeroll(\d+)_(\d{4}\d{2}\d{2})\.csv)\.done$', file_done, re.I)
 
 		if match is not None:
-			filename=match.group(1)
+			file_csv=match.group(1)
 
-			logger.info("File %s has been downloaded %s file found", filename, f)
+			logger.info("File %s has been downloaded %s file found", file_csv, file_done)
 
-			nf=os.path.join(archive_dir, filename)
+			nf=os.path.join(archive_dir, file_csv)
 
-			lf=os.path.join(download_dir, filename)
-			lfd=os.path.join(download_dir, f)
+			file_csv_download=os.path.join(download_dir, file_csv)
+			file_done_download=os.path.join(download_dir, file_done)
 
-			os.rename(lf,nf)
+			os.rename(file_csv_download,nf)
 
-			logger.info("Archived %s", filename)
+			logger.info("Archived %s", file_csv)
 
-			os.unlink(lfd)
+			os.unlink(file_done_download)
 
-			aclhistory[filename]='D' # downloaded
+			aclhistory[file_csv]='D' # downloaded
 
 	downloadcount=0
 
@@ -128,45 +128,45 @@ def main():
 			ftp_host.chdir('3_Days')
 
 			files=ftp_host.listdir(ftp_host.curdir)
-			for f in files:
+			for file_csv in files:
 
-				match = re.search('^(.*?)homeofficeroll(\d+)_(\d{4}\d{2}\d{2})\.csv$', f, re.I)
+				match = re.search('^(.*?)homeofficeroll(\d+)_(\d{4}\d{2}\d{2})\.csv$', file_csv, re.I)
 
 				download=False
 
 				if match is not None:
-					if f not in aclhistory.keys():
-						aclhistory[f]='N' # new
+					if file_csv not in aclhistory.keys():
+						aclhistory[file_csv]='N' # new
 
-					if aclhistory[f] == 'N':
+					if aclhistory[file_csv] == 'N':
 						download=True
 					else:
-						logger.debug("Skipping %s", f)
+						logger.debug("Skipping %s", file_csv)
 						continue
 
-					lf=os.path.join(download_dir,f)
-					slf=os.path.join(staging_dir,f)
+					file_csv_download=os.path.join(download_dir,file_csv)
+					file_csv_download=os.path.join(staging_dir,file_csv)
 
 					#protection against redownload
-					if os.path.isfile(lf) and os.path.getsize(lf) > 0 and os.path.getsize(lf) == ftp_host.stat(f).st_size:
+					if os.path.isfile(file_csv_download) and os.path.getsize(file_csv_download) > 0 and os.path.getsize(file_csv_download) == ftp_host.stat(file_csv).st_size:
 						logger.info("File exists")
 						download=False
-						aclhistory[f]='R' # ready
+						aclhistory[file_csv]='R' # ready
 
 					if download:
-						logger.info("Downloading %s to %s", f, lf)
+						logger.info("Downloading %s to %s", file_csv, file_csv_download)
 
-						ftp_host.download(f, slf) # remote, local (staging)
+						ftp_host.download(file_csv, file_csv_download) # remote, local (staging)
 
-						logger.debug("downloaded %s to %s", f, slf)
+						logger.debug("downloaded %s to %s", file_csv, file_csv_download)
 
-						if os.path.isfile(slf) and os.path.getsize(slf) > 0  and os.path.getsize(slf) == ftp_host.stat(f).st_size:
+						if os.path.isfile(file_csv_download) and os.path.getsize(file_csv_download) > 0  and os.path.getsize(file_csv_download) == ftp_host.stat(file_csv).st_size:
 							logger.debug("before virus scan")
-							if run_virus_scan(vscanexe, vscanopt, slf):
-								aclhistory[f]='R' # ready
+							if run_virus_scan(vscanexe, vscanopt, file_csv_download):
+								aclhistory[file_csv]='R' # ready
 
 								# move from staging to live
-								os.rename(slf,lf)
+								os.rename(file_csv_download,file_csv_download)
 
 								downloadcount+=1
 			# end for

--- a/ADT/WEB_Server/ftp_acl_web02.py
+++ b/ADT/WEB_Server/ftp_acl_web02.py
@@ -26,7 +26,6 @@ server=os.environ['server']
 username=os.environ['username']
 password=os.environ['password']
 
-#download_dir=time.strftime('%Y%m%d%H%I%S')
 download_dir='/ADT/data/acl'
 staging_dir='/ADT/stage/acl'
 quarantine_dir='/ADT/quarantine/acl'
@@ -47,22 +46,6 @@ def run_virus_scan(vscanexe, option, filename):
 	if virus_scan_return_code != 0: # Exit script if virus scan exe fails
 		logger.error('VIRUS SCAN FAILED %s', filename)
 		return False
-		#if os.path.isfile(filename):
-		#	# quarantine single
-		#	logger.error("Quarantine file %s", filename)
-		#	nf=os.path.join(quarantine_dir,  os.path.basename(filename))
-		#	os.rename(filename,nf)
-		#elif os.path.isdir(filename):
-		#	logger.error("Quarantine folder %s", filename)
-		#	for f in os.listdir(filename):
-		#		logger.error("Quarantine file %s", f)
-		#		nf=os.path.join(quarantine_dir,  os.path.basename(f))
-		#		os.rename(f,nf)
-		#else:
-		#	# hard failure
-		#	logger.error("Can't quarantine %s", filename)
-		#	print -2
-		#	os._exit(1)
 	else:
 		logger.debug('Virus scan OK')
 
@@ -90,14 +73,11 @@ def main():
 			level=logging.INFO
 		)
 
-
 	logger=logging.getLogger()
 
 	logger.info("Starting")
 
 	status=1
-
-	# Main
 
 	ProxySock.setup_http_proxy(os.environ['proxy'], 3128)
 
@@ -137,7 +117,6 @@ def main():
 			logger.info("Archived %s", filename)
 
 			os.unlink(lfd)
-			#os.unlink(lf)
 
 			aclhistory[filename]='D' # downloaded
 
@@ -174,7 +153,7 @@ def main():
 						download=False
 						aclhistory[f]='R' # ready
 
-					if download: # and match.group(3) == '20151005':
+					if download:
 						logger.info("Downloading %s to %s", f, lf)
 
 						ftp_host.download(f, slf) # remote, local (staging)
@@ -190,11 +169,6 @@ def main():
 								os.rename(slf,lf)
 
 								downloadcount+=1
-
-								# if oag then zap it...
-								#ftp_host.remove(f)
-#					else:
-#						aclhistory[f]='D'
 			# end for
 		except:
 			logger.exception("Failure")

--- a/ADT/WEB_Server/ftp_acl_web02.py
+++ b/ADT/WEB_Server/ftp_acl_web02.py
@@ -144,7 +144,7 @@ def main():
 						continue
 
 					file_csv_download = os.path.join(download_dir,file_csv)
-					file_csv_download = os.path.join(staging_dir,file_csv)
+					file_csv_staging = os.path.join(staging_dir,file_csv)
 
 					#protection against redownload
 					if os.path.isfile(file_csv_download) and os.path.getsize(file_csv_download) > 0 and os.path.getsize(file_csv_download) == ftp_host.stat(file_csv).st_size:
@@ -155,17 +155,17 @@ def main():
 					if download:
 						logger.info("Downloading %s to %s", file_csv, file_csv_download)
 
-						ftp_host.download(file_csv, file_csv_download) # remote, local (staging)
+						ftp_host.download(file_csv, file_csv_staging) # remote, local (staging)
 
-						logger.debug("downloaded %s to %s", file_csv, file_csv_download)
+						logger.debug("downloaded %s to %s", file_csv, file_csv_staging)
 
-						if os.path.isfile(file_csv_download) and os.path.getsize(file_csv_download) > 0 and os.path.getsize(file_csv_download) == ftp_host.stat(file_csv).st_size:
+						if os.path.isfile(file_csv_staging) and os.path.getsize(file_csv_staging) > 0 and os.path.getsize(file_csv_download) == ftp_host.stat(file_csv).st_size:
 							logger.debug("before virus scan")
-							if run_virus_scan(vscanexe, vscanopt, file_csv_download):
+							if run_virus_scan(vscanexe, vscanopt, file_csv_staging):
 								aclhistory[file_csv]='R' # ready
 
 								# move from staging to live
-								os.rename(file_csv_download,file_csv_download)
+								os.rename(file_csv_staging,file_csv_download)
 
 								downloadcount+=1
 			# end for

--- a/ADT/WEB_Server/ftp_oag_web02.py
+++ b/ADT/WEB_Server/ftp_oag_web02.py
@@ -102,28 +102,28 @@ def main():
 
 	# process download folder for downloaded files and move to archive folder
 	logger.debug("Scanning download folder %s", download_dir)
-	for f in os.listdir(download_dir):
-		logger.debug("File %s", f)
+	for file_done in os.listdir(download_dir):
+		logger.debug("File %s", file_done)
 
-		match = re.search('^(1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml)\.done$', f, re.I)
+		match = re.search('^(1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml)\.done$', file_done, re.I)
 
 		if match is not None:
-			filename=match.group(1)
+			file_xml=match.group(1)
 
-			logger.info("File %s has been downloaded %s file found", filename, f)
+			logger.info("File %s has been downloaded %s file found", file_xml, file_done)
 
-			nf=os.path.join(archive_dir, filename)
+			file_xml_archive=os.path.join(archive_dir, file_xml)
 
-			lf=os.path.join(download_dir, filename)
-			lfd=os.path.join(download_dir, f)
+			file_done_download=os.path.join(download_dir, file_xml)
+			file_done_archive=os.path.join(download_dir, file_done)
 
-			os.rename(lf,nf)
+			os.rename(file_done_download,file_xml_archive)
 
-			logger.info("Archived %s", filename)
+			logger.info("Archived %s", file_xml)
 
-			os.unlink(lfd)
+			os.unlink(file_done_archive)
 
-			oaghistory[filename]='D' # downloaded
+			oaghistory[file_xml]='D' # downloaded
 
 	downloadcount=0
 
@@ -131,43 +131,43 @@ def main():
 
 		try:
 			files=ftp_host.listdir(ftp_host.curdir)
-			for f in files:
-				match = re.search('^1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml$', f, re.I)
+			for file_xml in files:
+				match = re.search('^1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml$', file_xml, re.I)
 
 				download=False
 
 				if match is not None:
-					if f not in oaghistory.keys():
-						oaghistory[f]='N' # new
+					if file_xml not in oaghistory.keys():
+						oaghistory[file_xml]='N' # new
 
-					if oaghistory[f] == 'N':
+					if oaghistory[file_xml] == 'N':
 						download=True
 					else:
-						logger.debug("Skipping %s", f)
+						logger.debug("Skipping %s", file_xml)
 						continue
 
-					lf=os.path.join(download_dir,f)
-					slf=os.path.join(staging_dir,f)
+					file_xml_download=os.path.join(download_dir,file_xml)
+					file_xml_staging=os.path.join(staging_dir,file_xml)
 
 					#protection against redownload
-					if os.path.isfile(lf) and os.path.getsize(lf) > 0 and os.path.getsize(lf) == ftp_host.stat(f).st_size:
+					if os.path.isfile(file_xml_download) and os.path.getsize(file_xml_download) > 0 and os.path.getsize(file_xml_download) == ftp_host.stat(file_xml).st_size:
 						logger.info("File exists")
 
 						download=False
 
-						oaghistory[f]='R' # ready
+						oaghistory[file_xml]='R' # ready
 
-						logger.debug("purge %s", f)
-						ftp_host.remove(f)
+						logger.debug("purge %s", file_xml)
+						ftp_host.remove(file_xml)
 
 					if download:
-						logger.info("Downloading %s to %s", f, lf)
+						logger.info("Downloading %s to %s", file_xml, file_xml_download)
 
-						ftp_host.download(f, slf) # remote, local
+						ftp_host.download(file_xml, file_xml_staging) # remote, local
 
-						if os.path.isfile(slf) and os.path.getsize(slf) > 0 and os.path.getsize(slf) == ftp_host.stat(f).st_size:
-							logger.debug("purge %s", f)
-							ftp_host.remove(f)
+						if os.path.isfile(file_xml_staging) and os.path.getsize(file_xml_staging) > 0 and os.path.getsize(file_xml_staging) == ftp_host.stat(file_xml).st_size:
+							logger.debug("purge %s", file_xml)
+							ftp_host.remove(file_xml)
 			# end for
 
 			# batch virus scan on staging_dir for OAG
@@ -175,10 +175,10 @@ def main():
 			if run_virus_scan(vscanexe, vscanopt, staging_dir):
 				for f in os.listdir(staging_dir):
 					oaghistory[f]='R'
-					lf=os.path.join(download_dir,f)
-					sf=os.path.join(staging_dir,f)
-					logger.debug("move %s from staging to download %s",sf ,lf)
-					os.rename(sf,lf)
+					file_download=os.path.join(download_dir,f)
+					file_staging=os.path.join(staging_dir,f)
+					logger.debug("move %s from staging to download %s",file_staging ,file_download)
+					os.rename(file_staging,file_download)
 					downloadcount+=1
 		except:
 			logger.exception("Failure")

--- a/ADT/WEB_Server/ftp_oag_web02.py
+++ b/ADT/WEB_Server/ftp_oag_web02.py
@@ -20,24 +20,23 @@ import subprocess
 # local module
 import ProxySock
 
-log_file='/ADT/scripts/ftp_oag.log'
+log_file = '/ADT/scripts/ftp_oag.log'
 
 # OAG FTP details - purge downloaded files
-server=os.environ['server']
-username=os.environ['username']
-password=os.environ['password']
+server = os.environ['server']
+username = os.environ['username']
+password = os.environ['password']
 
-#download_dir=time.strftime('%Y%m%d%H%I%S')
-download_dir='/ADT/data/oag'
-staging_dir='/ADT/stage/oag'
-archive_dir='/ADT/archive/oag'
-quarantine_dir='/ADT/quarantine/oag'
+download_dir = '/ADT/data/oag'
+staging_dir = '/ADT/stage/oag'
+archive_dir = '/ADT/archive/oag'
+quarantine_dir = '/ADT/quarantine/oag'
 
-vscanexe='/usr/bin/clamdscan'
-vscanopt=''
+vscanexe = '/usr/bin/clamdscan'
+vscanopt = ''
 
 def run_virus_scan(vscanexe, option, filename):
-	logger=logging.getLogger()
+	logger = logging.getLogger()
 	logger.debug("Virus Scanning %s", filename)
 
 	# do quarantine move using via the virus scanner
@@ -76,17 +75,17 @@ def main():
 		)
 
 
-	logger=logging.getLogger()
+	logger = logging.getLogger()
 
 	logger.info("Starting")
 
-	status=1
+	status = 1
 
 	# Main
 
 	ProxySock.setup_http_proxy(os.environ['proxy'], 3128)
 
-	oaghistory=gdbm.open('oaghistory.db','c')
+	oaghistory = gdbm.open('oaghistory.db','c')
 
 	if not os.path.exists(download_dir):
 		os.makedirs(download_dir)
@@ -108,14 +107,14 @@ def main():
 		match = re.search('^(1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml)\.done$', file_done, re.I)
 
 		if match is not None:
-			file_xml=match.group(1)
+			file_xml = match.group(1)
 
 			logger.info("File %s has been downloaded %s file found", file_xml, file_done)
 
-			file_xml_archive=os.path.join(archive_dir, file_xml)
+			file_xml_archive = os.path.join(archive_dir, file_xml)
 
-			file_done_download=os.path.join(download_dir, file_xml)
-			file_done_archive=os.path.join(download_dir, file_done)
+			file_done_download = os.path.join(download_dir, file_xml)
+			file_done_archive = os.path.join(download_dir, file_done)
 
 			os.rename(file_done_download,file_xml_archive)
 
@@ -123,31 +122,31 @@ def main():
 
 			os.unlink(file_done_archive)
 
-			oaghistory[file_xml]='D' # downloaded
+			oaghistory[file_xml] = 'D' # downloaded
 
-	downloadcount=0
+	downloadcount = 0
 
 	with ftputil.FTPHost(server, username, password) as ftp_host:
 
 		try:
-			files=ftp_host.listdir(ftp_host.curdir)
+			files = ftp_host.listdir(ftp_host.curdir)
 			for file_xml in files:
 				match = re.search('^1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml$', file_xml, re.I)
 
-				download=False
+				download = False
 
 				if match is not None:
 					if file_xml not in oaghistory.keys():
-						oaghistory[file_xml]='N' # new
+						oaghistory[file_xml] = 'N' # new
 
 					if oaghistory[file_xml] == 'N':
-						download=True
+						download = True
 					else:
 						logger.debug("Skipping %s", file_xml)
 						continue
 
-					file_xml_download=os.path.join(download_dir,file_xml)
-					file_xml_staging=os.path.join(staging_dir,file_xml)
+					file_xml_download = os.path.join(download_dir,file_xml)
+					file_xml_staging = os.path.join(staging_dir,file_xml)
 
 					#protection against redownload
 					if os.path.isfile(file_xml_download) and os.path.getsize(file_xml_download) > 0 and os.path.getsize(file_xml_download) == ftp_host.stat(file_xml).st_size:
@@ -174,15 +173,15 @@ def main():
 			logger.debug("before virus scan")
 			if run_virus_scan(vscanexe, vscanopt, staging_dir):
 				for f in os.listdir(staging_dir):
-					oaghistory[f]='R'
-					file_download=os.path.join(download_dir,f)
-					file_staging=os.path.join(staging_dir,f)
+					oaghistory[f] = 'R'
+					file_download = os.path.join(download_dir,f)
+					file_staging = os.path.join(staging_dir,f)
 					logger.debug("move %s from staging to download %s",file_staging ,file_download)
 					os.rename(file_staging,file_download)
-					downloadcount+=1
+					downloadcount += 1
 		except:
 			logger.exception("Failure")
-			status=-2
+			status =- 2
 
 	# end with
 
@@ -191,7 +190,7 @@ def main():
 	logger.info("Downloaded %s files", downloadcount)
 
 	if downloadcount == 0:
-		status=-1
+		status =- 1
 
 	logger.info("Done Status %s", status)
 

--- a/ADT/WEB_Server/ftp_oag_web02.py
+++ b/ADT/WEB_Server/ftp_oag_web02.py
@@ -48,22 +48,6 @@ def run_virus_scan(vscanexe, option, filename):
 	if virus_scan_return_code != 0: # Exit script if virus scan exe fails
 		logger.error('VIRUS SCAN FAILED %s', filename)
 		return False
-		#if os.path.isfile(filename):
-		#	# quarantine single
-		#	logger.error("Quarantine file %s", filename)
-		#	nf=os.path.join(quarantine_dir,  os.path.basename(filename))
-		#	os.rename(filename,nf)
-		#elif os.path.isdir(filename):
-		#	logger.error("Quarantine folder %s", filename)
-		#	for f in os.listdir(filename):
-		#		logger.error("Quarantine file %s", f)
-		#		nf=os.path.join(quarantine_dir,  os.path.basename(f))
-		#		os.rename(f,nf)
-		#else:
-		#	# hard failure
-		#	logger.error("Can't quarantine %s", filename)
-		#	print -2
-		#	os._exit(1)
 	else:
 		logger.debug('Virus scan OK')
 
@@ -138,7 +122,6 @@ def main():
 			logger.info("Archived %s", filename)
 
 			os.unlink(lfd)
-			#os.unlink(lf)
 
 			oaghistory[filename]='D' # downloaded
 
@@ -149,9 +132,6 @@ def main():
 		try:
 			files=ftp_host.listdir(ftp_host.curdir)
 			for f in files:
-#				if downloadcount == 5:
-#					break
-
 				match = re.search('^1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml$', f, re.I)
 
 				download=False
@@ -188,13 +168,6 @@ def main():
 						if os.path.isfile(slf) and os.path.getsize(slf) > 0 and os.path.getsize(slf) == ftp_host.stat(f).st_size:
 							logger.debug("purge %s", f)
 							ftp_host.remove(f)
-							#logger.debug("before virus scan")
-							#if run_virus_scan(vscanexe, vscanopt, slf):
-							#	oaghistory[f]='R' # ready
-							#	os.rename(slf,lf)
-							#	downloadcount+=1
-							#
-							#	ftp_host.remove(f)
 			# end for
 
 			# batch virus scan on staging_dir for OAG

--- a/ADT/WEB_Server/sftp_oag_client_maytech.py
+++ b/ADT/WEB_Server/sftp_oag_client_maytech.py
@@ -97,20 +97,20 @@ def main():
 
 	# process download folder for downloaded files and move to archive folder
 	logger.debug("Scanning download folder %s", download_dir)
-	for f in os.listdir(download_dir):
-		logger.debug("File %s", f)
-		match = re.search('^(1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml)\.done$', f, re.I)
+	for file_done in os.listdir(download_dir):
+		logger.debug("File %s", file_done)
+		match = re.search('^(1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml)\.done$', file_done, re.I)
 
 		if match is not None:
-			filename=match.group(1)
-			logger.info("File %s has been downloaded %s file found", filename, f)
-			nf=os.path.join(archive_dir, filename)
-			lf=os.path.join(download_dir, filename)
-			lfd=os.path.join(download_dir, f)
-			os.rename(lf,nf)
-			logger.info("Archived %s", filename)
-			os.unlink(lfd)
-			oaghistory[filename]='D' # downloaded
+			file_xml = match.group(1)
+			logger.info("File %s has been downloaded %s file found", file_xml, file_done)
+			file_xml_archive = os.path.join(archive_dir, file_xml)
+			file_xml_download = os.path.join(download_dir, file_xml)
+			file_done_download = os.path.join(download_dir, file_done)
+			os.rename(file_xml_download,file_xml_archive)
+			logger.info("Archived %s", file_xml)
+			os.unlink(file_done_download)
+			oaghistory[file_xml]='D' # downloaded
 
 	downloadcount=0
     logger.debug("Connecting via SSH")

--- a/ADT/WEB_Server/sftp_oag_client_maytech.py
+++ b/ADT/WEB_Server/sftp_oag_client_maytech.py
@@ -21,9 +21,9 @@ import subprocess
 import paramiko
 
 
-ssh_remote_host='<see document for details: /Dropbox/Aker Systems (Home Office)/DQ Transition Project/notes>'
-ssh_remote_user='<see document for details: /Dropbox/Aker Systems (Home Office)/DQ Transition Project/notes>'
-ssh_private_key='<see document for details: /Dropbox/Aker Systems (Home Office)/DQ Transition Project/notes>'
+ssh_remote_host='<see doc for details: /Dropbox/Aker Systems (Home Office)/DQ Transition Project/notes>'
+ssh_remote_user='<see doc for details: /Dropbox/Aker Systems (Home Office)/DQ Transition Project/notes>'
+ssh_private_key='<see doc for details: /Dropbox/Aker Systems (Home Office)/DQ Transition Project/notes>'
 ssh_landing_dir='/'
 download_dir='/ADT/data/oag'
 staging_dir='/ADT/stage/oag'

--- a/ADT/WEB_Server/sftp_oag_client_maytech.py
+++ b/ADT/WEB_Server/sftp_oag_client_maytech.py
@@ -33,7 +33,7 @@ vscanexe='/usr/bin/clamdscan'
 vscanopt=''
 
 def ssh_login(in_host, in_user, in_keyfile):
-    logger=logging.getLogger()
+    logger = logging.getLogger()
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.client.AutoAddPolicy()) ## This line can be removed when the host is added to the known_hosts file
     privkey = paramiko.RSAKey.from_private_key_file (in_keyfile)
@@ -46,7 +46,7 @@ def ssh_login(in_host, in_user, in_keyfile):
 
 
 def run_virus_scan(vscanexe, option, filename):
-	logger=logging.getLogger()
+	logger = logging.getLogger()
 	logger.debug("Virus Scanning %s", filename)
 	# do quarantine move using via the virus scanner
 	virus_scan_return_code = subprocess.call([vscanexe,'--quiet','--move='+quarantine_dir, option, filename])
@@ -79,13 +79,13 @@ def main():
 			level=logging.INFO
 		)
 
-	logger=logging.getLogger()
+	logger = logging.getLogger()
 	logger.info("Starting")
-	status=1
+	status = 1
 
 	# Main
 	os.chdir('/ADT/scripts')
-	oaghistory=gdbm.open('/ADT/scripts/oaghistory.db','c')
+	oaghistory = gdbm.open('/ADT/scripts/oaghistory.db','c')
 	if not os.path.exists(download_dir):
 		os.makedirs(download_dir)
 	if not os.path.exists(archive_dir):
@@ -112,30 +112,30 @@ def main():
 			os.unlink(file_done_download)
 			oaghistory[file_xml]='D' # downloaded
 
-	downloadcount=0
+	downloadcount = 0
     logger.debug("Connecting via SSH")
-    ssh=ssh_login(ssh_remote_host, ssh_remote_user, ssh_private_key)
+    ssh = ssh_login(ssh_remote_host, ssh_remote_user, ssh_private_key)
     logger.debug("Connected")
     sftp = ssh.open_sftp()
 
 	try:
 		sftp.chdir(ssh_landing_dir)
-		files=sftp.listdir()
+		files = sftp.listdir()
 		for file_xml in files:
-			match=re.search('^1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml$', file_xml, re.I)
-			download=False
+			match = re.search('^1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml$', file_xml, re.I)
+			download = False
 			if match is not None:
 				if file_xml not in oaghistory.keys():
 					oaghistory[file_xml]='N' # new
 
                 if oaghistory[file_xml] == 'N':
-					download=True
+					download = True
 				else:
 					logger.debug("Skipping %s", file_xml)
 					continue
 
-                file_xml_download=os.path.join(download_dir,file_xml)
-				file_xml_staging=os.path.join(staging_dir,file_xml)
+                file_xml_download = os.path.join(download_dir,file_xml)
+				file_xml_staging = os.path.join(staging_dir,file_xml)
 
 				#protection against redownload
 				if os.path.isfile(file_xml_staging) and os.path.getsize(file_xml_staging) > 0 and os.path.getsize(file_xml_staging) == sftp.stat(file_xml).st_size:
@@ -161,8 +161,8 @@ def main():
 	if run_virus_scan(vscanexe, vscanopt, staging_dir):
 		for f in os.listdir(staging_dir):
 			oaghistory[f]='R'
-			file_download=os.path.join(download_dir,f)
-			file_staging=os.path.join(staging_dir,f)
+			file_download = os.path.join(download_dir,f)
+			file_staging = os.path.join(staging_dir,f)
 			logger.debug("move %s from staging to download %s",file_staging ,file_download)
 			os.rename(file_staging,file_download)
 			downloadcount+=1

--- a/ADT/WEB_Server/sftp_oag_client_maytech.py
+++ b/ADT/WEB_Server/sftp_oag_client_maytech.py
@@ -1,0 +1,182 @@
+#!/usr/bin/python
+
+# FTP OAG Script
+# Version 2 - maytech copy
+# ben.baylis@flightregister.net
+# ben@velvetbug.com
+# Flight Register/Velvet Bug Ltd
+
+# we only need the datetime class & the static function strptime from datetime module
+
+from datetime import datetime
+import dateutil.parser
+import re
+import time
+import sys
+import os
+import argparse
+import logging
+import gdbm
+import subprocess
+import paramiko
+
+
+ssh_remote_host='hodq.ftpstream.com'
+ssh_remote_user='oag_preprod'
+ssh_private_key='/home/SSM/.ssh/id_rsa'
+ssh_landing_dir='/' 
+download_dir='/ADT/data/oag'
+staging_dir='/ADT/stage/oag'
+archive_dir='/ADT/archive/oag'
+quarantine_dir='/ADT/quarantine/oag'
+vscanexe='/usr/bin/clamdscan'
+vscanopt=''
+
+def ssh_login(in_host, in_user, in_keyfile):
+        logger=logging.getLogger()
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.client.AutoAddPolicy()) ## This line can be removed when the host is added to the known_hosts file
+        privkey = paramiko.RSAKey.from_private_key_file (in_keyfile)
+        try:
+                ssh.connect(in_host, username=in_user,pkey=privkey )
+        except Exception, e:
+                logger.exception('SSH CONNECT ERROR')
+                os._exit(1)
+        return ssh
+
+
+def run_virus_scan(vscanexe, option, filename):
+	logger=logging.getLogger()
+	logger.debug("Virus Scanning %s", filename)
+	# do quarantine move using via the virus scanner
+	virus_scan_return_code = subprocess.call([vscanexe,'--quiet','--move='+quarantine_dir, option, filename])
+	logger.debug("Virus scan result %s", virus_scan_return_code)
+	if virus_scan_return_code != 0: # Exit script if virus scan exe fails
+		logger.error('VIRUS SCAN FAILED %s', filename)
+		return False
+	else:
+		logger.debug('Virus scan OK')
+	return True
+# end def run_virus_scan
+
+
+def main():
+	parser = argparse.ArgumentParser(description='OAG SFTP Downloader')
+	parser.add_argument('-D','--DEBUG',  default=False, action='store_true', help='Debug mode logging')
+	args = parser.parse_args()
+	if args.DEBUG:
+		logging.basicConfig(
+			filename='/ADT/scripts/sftp_oag_maytech.log',
+			format="%(asctime)s\t%(name)s\t%(levelname)s\t%(message)s",
+			datefmt='%Y-%m-%d %H:%M:%S', 
+			level=logging.DEBUG
+		)
+	else:
+		logging.basicConfig(
+			filename='/ADT/scripts/sftp_oag_maytech.log',
+			format="%(asctime)s\t%(name)s\t%(levelname)s\t%(message)s",
+			datefmt='%Y-%m-%d %H:%M:%S', 
+			level=logging.INFO
+		)
+
+
+	logger=logging.getLogger()
+	logger.info("Starting")
+	status=1
+
+	# Main
+	os.chdir('/ADT/scripts')
+	oaghistory=gdbm.open('/ADT/scripts/oaghistory.db','c')
+	if not os.path.exists(download_dir):
+		os.makedirs(download_dir)
+	if not os.path.exists(archive_dir):
+		os.makedirs(archive_dir)
+	if not os.path.exists(staging_dir):
+		os.makedirs(staging_dir)
+	if not os.path.exists(quarantine_dir):
+		os.makedirs(quarantine_dir)
+
+	# process download folder for downloaded files and move to archive folder
+	logger.debug("Scanning download folder %s", download_dir)
+	for f in os.listdir(download_dir):
+		logger.debug("File %s", f)
+		match = re.search('^(1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml)\.done$', f, re.I)
+		
+		if match is not None:
+			filename=match.group(1)
+			logger.info("File %s has been downloaded %s file found", filename, f)
+			nf=os.path.join(archive_dir, filename)
+			lf=os.path.join(download_dir, filename)
+			lfd=os.path.join(download_dir, f)
+			os.rename(lf,nf)
+			logger.info("Archived %s", filename)
+			os.unlink(lfd)
+			oaghistory[filename]='D' # downloaded
+			
+	downloadcount=0
+        logger.debug("Connecting via SSH")
+        ssh=ssh_login(ssh_remote_host, ssh_remote_user, ssh_private_key)
+        logger.debug("Connected")
+        sftp = ssh.open_sftp()
+		
+	try:
+		sftp.chdir(ssh_landing_dir) 
+		files=sftp.listdir()
+		for f in files:
+			match = re.search('^1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml$', f, re.I)
+			download=False
+			if match is not None:
+				if f not in oaghistory.keys():
+					oaghistory[f]='N' # new				
+				if oaghistory[f] == 'N':
+					download=True
+				else:
+					logger.debug("Skipping %s", f)
+					continue
+				lf=os.path.join(download_dir,f)
+				slf=os.path.join(staging_dir,f)
+
+				#protection against redownload
+				if os.path.isfile(slf) and os.path.getsize(slf) > 0 and os.path.getsize(slf) == sftp.stat(f).st_size:
+					logger.info("File exists")		
+					download=False
+					oaghistory[f]='R' # ready
+					logger.debug("purge %s", f)
+					sftp.remove(f)											
+				if download:
+					logger.info("Downloading %s to %s", f, slf)
+					sftp.get(f, slf) # remote, local
+					if os.path.isfile(slf) and os.path.getsize(slf) > 0 and os.path.getsize(slf) == sftp.stat(f).st_size:
+						logger.debug("purge %s", f)
+						sftp.remove(f)
+
+		# end for
+	except:
+		logger.exception("Failure")
+		status=-2
+	# end with					
+
+	# batch virus scan on staging_dir for OAG
+	logger.debug("before virus scan")
+	if run_virus_scan(vscanexe, vscanopt, staging_dir):
+		for f in os.listdir(staging_dir):					
+			oaghistory[f]='R'
+			lf=os.path.join(download_dir,f)
+			sf=os.path.join(staging_dir,f)
+			logger.debug("move %s from staging to download %s",sf ,lf)
+			os.rename(sf,lf)
+			downloadcount+=1
+	
+	oaghistory.close()
+	logger.info("Downloaded %s files", downloadcount)
+
+	if downloadcount == 0:
+		status=-1
+
+	logger.info("Done Status %s", status)
+	print status
+	
+# end def main
+
+if __name__ == '__main__':
+    main()

--- a/ADT/WEB_Server/sftp_oag_client_maytech.py
+++ b/ADT/WEB_Server/sftp_oag_client_maytech.py
@@ -21,9 +21,9 @@ import subprocess
 import paramiko
 
 
-ssh_remote_host='<see document for details>'
-ssh_remote_user='<see document for details>'
-ssh_private_key='<see document for details>'
+ssh_remote_host='<see document for details: /Dropbox/Aker Systems (Home Office)/DQ Transition Project/notes>'
+ssh_remote_user='<see document for details: /Dropbox/Aker Systems (Home Office)/DQ Transition Project/notes>'
+ssh_private_key='<see document for details: /Dropbox/Aker Systems (Home Office)/DQ Transition Project/notes>'
 ssh_landing_dir='/'
 download_dir='/ADT/data/oag'
 staging_dir='/ADT/stage/oag'

--- a/ADT/WEB_Server/sftp_oag_client_maytech.py
+++ b/ADT/WEB_Server/sftp_oag_client_maytech.py
@@ -121,35 +121,35 @@ def main():
 	try:
 		sftp.chdir(ssh_landing_dir)
 		files=sftp.listdir()
-		for f in files:
-			match = re.search('^1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml$', f, re.I)
+		for file_xml in files:
+			match=re.search('^1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml$', file_xml, re.I)
 			download=False
 			if match is not None:
-				if f not in oaghistory.keys():
-					oaghistory[f]='N' # new
+				if file_xml not in oaghistory.keys():
+					oaghistory[file_xml]='N' # new
 
-                if oaghistory[f] == 'N':
+                if oaghistory[file_xml] == 'N':
 					download=True
 				else:
-					logger.debug("Skipping %s", f)
+					logger.debug("Skipping %s", file_xml)
 					continue
 
-                lf=os.path.join(download_dir,f)
-				slf=os.path.join(staging_dir,f)
+                file_xml_download=os.path.join(download_dir,file_xml)
+				file_xml_staging=os.path.join(staging_dir,file_xml)
 
 				#protection against redownload
-				if os.path.isfile(slf) and os.path.getsize(slf) > 0 and os.path.getsize(slf) == sftp.stat(f).st_size:
+				if os.path.isfile(file_xml_staging) and os.path.getsize(file_xml_staging) > 0 and os.path.getsize(file_xml_staging) == sftp.stat(file_xml).st_size:
 					logger.info("File exists")
-					download=False
-					oaghistory[f]='R' # ready
-					logger.debug("purge %s", f)
-					sftp.remove(f)
+					download = False
+					oaghistory[file_xml] = 'R' # ready
+					logger.debug("purge %s", file_xml)
+					sftp.remove(file_xml)
 				if download:
-					logger.info("Downloading %s to %s", f, slf)
-					sftp.get(f, slf) # remote, local
-					if os.path.isfile(slf) and os.path.getsize(slf) > 0 and os.path.getsize(slf) == sftp.stat(f).st_size:
-						logger.debug("purge %s", f)
-						sftp.remove(f)
+					logger.info("Downloading %s to %s", file_xml, file_xml_staging)
+					sftp.get(file_xml, file_xml_staging) # remote, local
+					if os.path.isfile(file_xml_staging) and os.path.getsize(file_xml_staging) > 0 and os.path.getsize(file_xml_staging) == sftp.stat(file_xml).st_size:
+						logger.debug("purge %s", file_xml)
+						sftp.remove(file_xml)
 		# end for
 	except:
 		logger.exception("Failure")

--- a/ADT/WEB_Server/sftp_oag_client_maytech.py
+++ b/ADT/WEB_Server/sftp_oag_client_maytech.py
@@ -21,10 +21,10 @@ import subprocess
 import paramiko
 
 
-ssh_remote_host='hodq.ftpstream.com'
-ssh_remote_user='oag_preprod'
-ssh_private_key='/home/SSM/.ssh/id_rsa'
-ssh_landing_dir='/' 
+ssh_remote_host='<see document for details>'
+ssh_remote_user='<see document for details>'
+ssh_private_key='<see document for details>'
+ssh_landing_dir='/'
 download_dir='/ADT/data/oag'
 staging_dir='/ADT/stage/oag'
 archive_dir='/ADT/archive/oag'
@@ -68,14 +68,14 @@ def main():
 		logging.basicConfig(
 			filename='/ADT/scripts/sftp_oag_maytech.log',
 			format="%(asctime)s\t%(name)s\t%(levelname)s\t%(message)s",
-			datefmt='%Y-%m-%d %H:%M:%S', 
+			datefmt='%Y-%m-%d %H:%M:%S',
 			level=logging.DEBUG
 		)
 	else:
 		logging.basicConfig(
 			filename='/ADT/scripts/sftp_oag_maytech.log',
 			format="%(asctime)s\t%(name)s\t%(levelname)s\t%(message)s",
-			datefmt='%Y-%m-%d %H:%M:%S', 
+			datefmt='%Y-%m-%d %H:%M:%S',
 			level=logging.INFO
 		)
 
@@ -101,7 +101,7 @@ def main():
 	for f in os.listdir(download_dir):
 		logger.debug("File %s", f)
 		match = re.search('^(1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml)\.done$', f, re.I)
-		
+
 		if match is not None:
 			filename=match.group(1)
 			logger.info("File %s has been downloaded %s file found", filename, f)
@@ -112,22 +112,22 @@ def main():
 			logger.info("Archived %s", filename)
 			os.unlink(lfd)
 			oaghistory[filename]='D' # downloaded
-			
+
 	downloadcount=0
         logger.debug("Connecting via SSH")
         ssh=ssh_login(ssh_remote_host, ssh_remote_user, ssh_private_key)
         logger.debug("Connected")
         sftp = ssh.open_sftp()
-		
+
 	try:
-		sftp.chdir(ssh_landing_dir) 
+		sftp.chdir(ssh_landing_dir)
 		files=sftp.listdir()
 		for f in files:
 			match = re.search('^1124_(SH)?(\d\d\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)_(\d\d)(.*?)\.xml$', f, re.I)
 			download=False
 			if match is not None:
 				if f not in oaghistory.keys():
-					oaghistory[f]='N' # new				
+					oaghistory[f]='N' # new
 				if oaghistory[f] == 'N':
 					download=True
 				else:
@@ -138,11 +138,11 @@ def main():
 
 				#protection against redownload
 				if os.path.isfile(slf) and os.path.getsize(slf) > 0 and os.path.getsize(slf) == sftp.stat(f).st_size:
-					logger.info("File exists")		
+					logger.info("File exists")
 					download=False
 					oaghistory[f]='R' # ready
 					logger.debug("purge %s", f)
-					sftp.remove(f)											
+					sftp.remove(f)
 				if download:
 					logger.info("Downloading %s to %s", f, slf)
 					sftp.get(f, slf) # remote, local
@@ -154,19 +154,19 @@ def main():
 	except:
 		logger.exception("Failure")
 		status=-2
-	# end with					
+	# end with
 
 	# batch virus scan on staging_dir for OAG
 	logger.debug("before virus scan")
 	if run_virus_scan(vscanexe, vscanopt, staging_dir):
-		for f in os.listdir(staging_dir):					
+		for f in os.listdir(staging_dir):
 			oaghistory[f]='R'
 			lf=os.path.join(download_dir,f)
 			sf=os.path.join(staging_dir,f)
 			logger.debug("move %s from staging to download %s",sf ,lf)
 			os.rename(sf,lf)
 			downloadcount+=1
-	
+
 	oaghistory.close()
 	logger.info("Downloaded %s files", downloadcount)
 
@@ -175,7 +175,7 @@ def main():
 
 	logger.info("Done Status %s", status)
 	print status
-	
+
 # end def main
 
 if __name__ == '__main__':

--- a/ADT/WEB_Server/sftp_oag_client_maytech.py
+++ b/ADT/WEB_Server/sftp_oag_client_maytech.py
@@ -161,10 +161,10 @@ def main():
 	if run_virus_scan(vscanexe, vscanopt, staging_dir):
 		for f in os.listdir(staging_dir):
 			oaghistory[f]='R'
-			lf=os.path.join(download_dir,f)
-			sf=os.path.join(staging_dir,f)
-			logger.debug("move %s from staging to download %s",sf ,lf)
-			os.rename(sf,lf)
+			file_download=os.path.join(download_dir,f)
+			file_staging=os.path.join(staging_dir,f)
+			logger.debug("move %s from staging to download %s",file_staging ,file_download)
+			os.rename(file_staging,file_download)
 			downloadcount+=1
 
 	oaghistory.close()

--- a/ADT/WEB_Server/sftp_oag_client_maytech.py
+++ b/ADT/WEB_Server/sftp_oag_client_maytech.py
@@ -33,16 +33,16 @@ vscanexe='/usr/bin/clamdscan'
 vscanopt=''
 
 def ssh_login(in_host, in_user, in_keyfile):
-        logger=logging.getLogger()
-        ssh = paramiko.SSHClient()
-        ssh.set_missing_host_key_policy(paramiko.client.AutoAddPolicy()) ## This line can be removed when the host is added to the known_hosts file
-        privkey = paramiko.RSAKey.from_private_key_file (in_keyfile)
-        try:
-                ssh.connect(in_host, username=in_user,pkey=privkey )
-        except Exception, e:
-                logger.exception('SSH CONNECT ERROR')
-                os._exit(1)
-        return ssh
+    logger=logging.getLogger()
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.client.AutoAddPolicy()) ## This line can be removed when the host is added to the known_hosts file
+    privkey = paramiko.RSAKey.from_private_key_file (in_keyfile)
+    try:
+        ssh.connect(in_host, username=in_user,pkey=privkey )
+    except Exception, e:
+        logger.exception('SSH CONNECT ERROR')
+        os._exit(1)
+    return ssh
 
 
 def run_virus_scan(vscanexe, option, filename):
@@ -79,7 +79,6 @@ def main():
 			level=logging.INFO
 		)
 
-
 	logger=logging.getLogger()
 	logger.info("Starting")
 	status=1
@@ -114,10 +113,10 @@ def main():
 			oaghistory[filename]='D' # downloaded
 
 	downloadcount=0
-        logger.debug("Connecting via SSH")
-        ssh=ssh_login(ssh_remote_host, ssh_remote_user, ssh_private_key)
-        logger.debug("Connected")
-        sftp = ssh.open_sftp()
+    logger.debug("Connecting via SSH")
+    ssh=ssh_login(ssh_remote_host, ssh_remote_user, ssh_private_key)
+    logger.debug("Connected")
+    sftp = ssh.open_sftp()
 
 	try:
 		sftp.chdir(ssh_landing_dir)
@@ -128,12 +127,14 @@ def main():
 			if match is not None:
 				if f not in oaghistory.keys():
 					oaghistory[f]='N' # new
-				if oaghistory[f] == 'N':
+
+                if oaghistory[f] == 'N':
 					download=True
 				else:
 					logger.debug("Skipping %s", f)
 					continue
-				lf=os.path.join(download_dir,f)
+
+                lf=os.path.join(download_dir,f)
 				slf=os.path.join(staging_dir,f)
 
 				#protection against redownload
@@ -149,7 +150,6 @@ def main():
 					if os.path.isfile(slf) and os.path.getsize(slf) > 0 and os.path.getsize(slf) == sftp.stat(f).st_size:
 						logger.debug("purge %s", f)
 						sftp.remove(f)
-
 		# end for
 	except:
 		logger.exception("Failure")


### PR DESCRIPTION
Went through the scripts renaming variables like f, lf, nf, slf to follow a more meaningful convention.

These all related to files, so they all began with "file_"
The second section was the extension - one of these: xml, csv, done
The third section only appears if the file has a path.

e.g.
The variable associated with file ABC.xml would be ***file_xml***
For a file ABC.xml in the download folder, the variable would be ***file_xml_download***

Some whitespace was removed automatically by Atom.  No changes to logic were done.